### PR TITLE
composer.json updates...

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,12 +11,12 @@
     "require": {
         "silverstripe/recipe-plugin": "^1",
         "silverstripe/recipe-core": "^1@dev || ^4@dev",
+        "squizlabs/php_codesniffer": "^3",
         "phpunit/phpunit": "^5.7",
-        "silverstripe/testsession": "^2.1",
-        "silverstripe/behat-extension": "^4",
-        "silverstripe/mink-facebook-web-driver": "^1",
-        "silverstripe/serve": "^2",
-        "squizlabs/php_codesniffer": "^3"
+        "silverstripe/testsession": "2.1.x-dev",
+        "silverstripe/behat-extension": "4.x-dev",
+        "silverstripe/mink-facebook-web-driver": "1.x-dev",
+        "silverstripe/serve": "2.x-dev"
     },
     "extra": {
         "project-files": [


### PR DESCRIPTION
Adjusting composer.json to require dev versions and converting all dependencies to dev (require-dev)

This might be a slightly opinionated PR but our recipes usually contain dev dependencies, and releases have stable versions tagged. It makes sense (in my opinion) to have recipes using the latest development versions of packages (that we "maintain"). Also, if this recipe is ever added to projects, it makes sense that none of this is included when running `composer install --no-dev`.