### PR TITLE
FIX: Allow the use of stable tags

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,8 @@
         "silverstripe/recipe-plugin": "^1",
         "silverstripe/recipe-core": "^1@dev || ^4@dev",
         "phpunit/phpunit": "^5.7",
-        "silverstripe/behat-extension": "4.x-dev",
-        "silverstripe/serve": "2.x-dev",
+        "silverstripe/behat-extension": "^4.2",
+        "silverstripe/serve": "^2.2",
         "squizlabs/php_codesniffer": "^3"
     },
     "extra": {


### PR DESCRIPTION
Pinning to a specific branch on a reusable module is an antipattern as
It is very flexible - projects will be blocked from installing stable
tags.

If there is code in a future branch that you need, then you should pin
to a not-yet-existing branch, and lower the min-stability of your parent
project to development.

Better yet, the modules with necessary code should have a stable tag
created.