### PR TITLE
Recommend this module only when using behat

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,5 @@ All bootstrapping files, including PHPCS style config, are included.
 
 See the [recipe plugin](https://github.com/silverstripe/recipe-plugin) page for instructions on how
 SilverStripe recipes work.
+
+**Note:** If you are not using Behat for end-to-end testing on your module, it is recommended that you install PHPUnit and CodeSniffer directly.


### PR DESCRIPTION
When you're not using behat for end-to-end testing, I would recommend that we avoid the use of this recipe in favour of simply inlining the two other relevant requirements. It has a complex dependency chain that can conflicts with other packages (eg https://github.com/silverstripe/silverstripe-event-dispatcher/issues/8) and is generally only worth the trouble if you're actually using behat for testing.