### PR TITLE
DEP Require at least 4.4 of behat-extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "silverstripe/recipe-plugin": "^1",
         "silverstripe/recipe-core": "^1@dev || ^4@dev",
         "sminnee/phpunit": "^5.7",
-        "silverstripe/behat-extension": "^4.2",
+        "silverstripe/behat-extension": "^4.4",
         "silverstripe/serve": "^2.2",
         "squizlabs/php_codesniffer": "^3"
     },


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-behat-extension/issues/200

behat-extension 4.4.0 has been tagged so this is good to go