### PR TITLE
DEP Conflict older versions of symfony components

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,10 @@
             "*.xml.dist"
         ]
     },
+    "conflict": {
+        "symfony/process": "<4.4.44",
+        "symfony/var-exporter": "<4.4.44"
+    },
     "minimum-stability": "dev",
     "prefer-stable": true
 }


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/10349

Fix https://github.com/silverstripe/recipe-testing/runs/7757114077?check_suite_focus=true
` Fatal error: During inheritance of IteratorAggregate: Uncaught Return type of Symfony\Component\Process\Process::getIterator($flags = 0) should either be compatible with IteratorAggregate::getIterator(): Traversable, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice`

Note: this is really just a temporary thing to get the build to pass, we'll symfony/* will be replaced v6 components