### PR TITLE
MNT Do not look for tests in serve directory

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,7 +3,6 @@
     <testsuites>
         <testsuite name="recipe-testing">
             <directory>vendor/silverstripe/behat-extension/tests</directory>
-            <directory>vendor/silverstripe/serve/tests</directory>
         </testsuite>
     </testsuites>
 </phpunit>


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/199

Fixes https://github.com/silverstripe/recipe-testing/actions/runs/8014542947/job/21893486177

`Test directory "/home/runner/work/recipe-testing/recipe-testing/vendor/silverstripe/serve/tests" not found`