### PR TITLE
DEP Conflict behat/gherkin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
     },
     "conflict": {
         "symfony/process": "<4.4.44",
-        "symfony/var-exporter": "<4.4.44"
+        "symfony/var-exporter": "<4.4.44",
+        "behat/gherkin": ">=4.13.0"
     },
     "minimum-stability": "dev",
     "prefer-stable": true


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/403

This fixes all the broken CMS 5 behat builds e.g. https://github.com/silverstripe/silverstripe-admin/actions/runs/14921935003/job/41918809444

The core issue is that behat/gherkin introduced PSR-4 file paths instead of PSR-0 file paths - https://github.com/Behat/Gherkin/releases/tag/v4.13.0

This meant that behat/behat needs to be at least [3.20.0](https://github.com/Behat/Behat/releases/tag/v3.20.0) or the special [3.16.1](https://github.com/Behat/Behat/releases/tag/v3.16.1) release (which won't be merged up)

CMS 5 is restricted to behat/behat 3.19.0 because of a the major version of nikic/php-parser: ^5.  CMS 6 can use behat 3.21.1 so it's not a concern

On CMS 5 we need to either restrict behat/behat to ~3.16, or restrict behat/gherkin to less than 4.13.0.  I've gone with the latter option

